### PR TITLE
[cli] Only fetch specific submodules if `paths` option is given

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,10 @@ const main = async () => {
     throw new Error('git commit history depth must be greater than 0');
   }
 
-  const submodules = await fetchSubmodules();
+  const specificPaths = parsedOptions.paths ?? [];
+  const submodules = await fetchSubmodules({
+    paths: specificPaths.length > 0 ? specificPaths : null,
+  });
   await clone({ githubToken, depth, submodules });
 };
 


### PR DESCRIPTION
```
░▒▓ ~/vercel-submodules  on junhoyeo/only-clone-specific *5 +3 !2  yarn build && yarn start --all                                                                              ✔  at 07:50:11 ▓▒░
yarn run v1.22.19
$ tsc
✨  Done in 1.46s.
yarn run v1.22.19
$ node lib/index.js --all
Clone Success Submodule src/juno@e0cfea7
Clone Success Submodule test@170a609
✨  Done in 2.56s.

░▒▓ ~/vercel-submodules  on junhoyeo/only-clone-specific *5 +3 !2  yarn build && yarn start --paths test                                                             ✔  took 4s  at 07:50:18 ▓▒░
yarn run v1.22.19
$ tsc
✨  Done in 1.48s.
yarn run v1.22.19
$ node lib/index.js --paths test
Clone Success Submodule test@170a609
✨  Done in 4.25s.

░▒▓ ~/vercel-submodules  on junhoyeo/only-clone-specific *5 +3 !2  yarn build && yarn start --paths ./test                                                           ✔  took 6s  at 07:50:29 ▓▒░
yarn run v1.22.19
$ tsc
✨  Done in 1.67s.
yarn run v1.22.19
$ node lib/index.js --paths ./test
Clone Success Submodule test@170a609
✨  Done in 1.44s.

░▒▓ ~/vercel-submodules  on junhoyeo/only-clone-specific *5 +3 !2  yarn build && yarn start --paths ./src/juno                                                       ✔  took 3s  at 07:50:34 ▓▒░
yarn run v1.22.19
$ tsc
✨  Done in 1.50s.
yarn run v1.22.19
$ node lib/index.js --paths ./src/juno
Clone Success Submodule src/juno@e0cfea7
✨  Done in 1.48s.

░▒▓ ~/vercel-submodules  on junhoyeo/only-clone-specific *5 +3 !2  yarn build && yarn start --paths ./src/juno src/juno test                                         ✔  took 3s  at 07:50:45 ▓▒░
yarn run v1.22.19
$ tsc
✨  Done in 1.49s.
yarn run v1.22.19
$ node lib/index.js --paths ./src/juno src/juno test
Clone Success Submodule src/juno@e0cfea7
Clone Success Submodule test@170a609
✨  Done in 3.50s.
```