### PR TITLE
[cli] Adopt GitHub fine-graned token

### DIFF
--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -6,23 +6,24 @@ import * as zx from 'zx';
 import { insideDir } from '../utils/filesystem.js';
 import { Submodule } from '../utils/submodules.js';
 
-const convertToAuthURL = (url: string, githubToken: string): string => {
+const convertToAuthURL = (url: string, githubToken: string, isFineGrained: boolean): string => {
   const parsed = GitUrlParse(url);
-  parsed.token = githubToken;
+  parsed.token = isFineGrained ? `oauth2:${githubToken}` : githubToken;
   return GitUrlParse.stringify(parsed, 'https');
 };
 
 type CloneOptions = {
   githubToken: string;
+  isFineGrained: boolean;
   depth: number;
   submodules: Submodule[];
 };
-export const clone = async ({ githubToken, depth, submodules }: CloneOptions) => {
+export const clone = async ({ githubToken, isFineGrained, depth, submodules }: CloneOptions) => {
   const topLevel = (await zx.$`git rev-parse --show-toplevel`).stdout.trim();
 
   for (const submodule of submodules) {
     const submoduleDir = path.join(topLevel, submodule.gitModulePath);
-    const submoduleURL = !!githubToken ? convertToAuthURL(submodule.url, githubToken) : submodule.url;
+    const submoduleURL = !!githubToken ? convertToAuthURL(submodule.url, githubToken, isFineGrained) : submodule.url;
 
     await zx.$`rm -rf ${submoduleDir}`.catch(() => {
       /* ignored */

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const OPTIONS = {
   '--paths': 'paths',
   '--depth': 'depth',
   '--token': 'token',
+  '--fg-token': 'fgToken',
 } as const;
 type OptionAlias = keyof typeof OPTIONS;
 type Option = typeof OPTIONS[OptionAlias];
@@ -43,8 +44,12 @@ const main = async () => {
   zx.$.verbose = !!parsedOptions.verbose;
 
   let githubToken: string = '';
+  let isFineGrained: boolean = false;
   if (parsedOptions.token?.[0]) {
     [githubToken] = parsedOptions.token;
+  } else if (parsedOptions.fgToken?.[0]) {
+    [githubToken] = parsedOptions.fgToken;
+    isFineGrained = true;
   } else {
     githubToken = process.env.GITHUB_TOKEN || '';
   }
@@ -61,7 +66,7 @@ const main = async () => {
   const submodules = await fetchSubmodules({
     paths: specificPaths.length > 0 ? specificPaths : null,
   });
-  await clone({ githubToken, depth, submodules });
+  await clone({ githubToken, isFineGrained, depth, submodules });
 };
 
 main().catch((error) => {


### PR DESCRIPTION
Hello, I'm also using vercel and trying to include git submodule in build time.

This script is using classic Personal Access Token, but I wanna use [new fine-graned PAT](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/) because I work for a company and it's more suitable for access management for organization private repo.

It seems to need some fix to URL to use fine-grained token. ([like this](https://stackoverflow.com/questions/74532852/github-clone-repo-with-fine-grained-personal-access-tokens-pat))
So I added `--fg-token` flag, and fix code to add `oauth2:` before token in Github URL if fine-grained token is given.

I would appreciate if you could review 🙏.